### PR TITLE
When printing status, filter pull requests only by commits with IDs

### DIFF
--- a/git-kspr/src/main/kotlin/sims/michael/gitkspr/GitKspr.kt
+++ b/git-kspr/src/main/kotlin/sims/michael/gitkspr/GitKspr.kt
@@ -77,7 +77,7 @@ class GitKspr(
         val remoteBranchesById = gitClient.getRemoteBranchesById()
         val stack = gitClient.getLocalCommitStack(remoteName, refSpec.localRef, refSpec.remoteRef)
         val prsById = if (stack.isNotEmpty()) {
-            ghClient.getPullRequests(stack).associateBy(PullRequest::commitId)
+            ghClient.getPullRequests(stack.filter { commit -> commit.id != null }).associateBy(PullRequest::commitId)
         } else {
             emptyMap()
         }


### PR DESCRIPTION
When printing status, filter pull requests only by commits with IDs

If we have commits without IDs, by definition they shouldn't have been
pushed. I may need to think on this and revisit...

commit-id: 91b6e496
