### PR TITLE
Swap Jsch for mwiede/jsch fork

### DIFF
--- a/git-kspr/build.gradle.kts
+++ b/git-kspr/build.gradle.kts
@@ -56,6 +56,14 @@ dependencies {
     testImplementation(libs.jgit.junit)
 }
 
+configurations.all {
+    resolutionStrategy.dependencySubstitution {
+        substitute(module("com.jcraft:jsch:0.1.55"))
+            .using(module("com.github.mwiede:jsch:0.2.13"))
+            .because("See https://github.com/mwiede/jsch#why-should-you-use-this-library")
+    }
+}
+
 // Apply a specific Java toolchain to ease working on different environments.
 java {
     toolchain {


### PR DESCRIPTION
Swap Jsch for mwiede/jsch fork

https://github.com/mwiede/jsch#why-should-you-use-this-library

commit-id: 2e630d42
