### PR TITLE
Removing 'latest' os's from build

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -26,7 +26,6 @@ jobs:
     needs: ['create_release']
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest']
         include:
           - os: 'ubuntu-20.04'
             label: 'linux'


### PR DESCRIPTION
Removing 'latest' os's from build


commit-id: f5e9ccc7
