### PR TITLE
Fix logic bug in GitKspr.push

### DIFF
--- a/git-kspr/src/main/kotlin/sims/michael/gitkspr/GitKspr.kt
+++ b/git-kspr/src/main/kotlin/sims/michael/gitkspr/GitKspr.kt
@@ -55,6 +55,9 @@ class GitKspr(
                     baseRefName = prevCommit?.toRemoteRefName() ?: refSpec.remoteRef,
                     title = currentCommit.shortMessage,
                     body = currentCommit.fullMessage,
+                    checksPass = existingPr?.checksPass,
+                    approved = existingPr?.approved,
+                    checkConclusionStates = existingPr?.checkConclusionStates.orEmpty(),
                 )
             }
             .filter { pr -> existingPrsByCommitId[pr.commitId] != pr }


### PR DESCRIPTION
Fix logic bug in GitKspr.push

I should be copying all properties here

commit-id: e4275501
