### PR TITLE
Restore mechanism in GitHubTestHarness to create commits without IDs

### DIFF
--- a/git-kspr/src/test/kotlin/sims/michael/gitkspr/GitKsprTest.kt
+++ b/git-kspr/src/test/kotlin/sims/michael/gitkspr/GitKsprTest.kt
@@ -650,10 +650,17 @@ interface GitKsprTest {
                 listOf("0", "1", "2"),
                 testCase {
                     repository {
-                        commit { title = "0" }
-                        commit { title = "1" }
+                        commit {
+                            title = "0"
+                            id = ""
+                        }
+                        commit {
+                            title = "1"
+                            id = ""
+                        }
                         commit {
                             title = "2"
+                            id = ""
                             localRefs += "main"
                         }
                     }
@@ -666,10 +673,17 @@ interface GitKsprTest {
                     repository {
                         commit { title = "A" }
                         commit { title = "B" }
-                        commit { title = "0" }
-                        commit { title = "1" }
+                        commit {
+                            title = "0"
+                            id = ""
+                        }
+                        commit {
+                            title = "1"
+                            id = ""
+                        }
                         commit {
                             title = "2"
+                            id = ""
                             localRefs += "main"
                         }
                     }
@@ -680,12 +694,27 @@ interface GitKsprTest {
                 listOf("A", "B", "0", "1", "2", "C", "D"),
                 testCase {
                     repository {
-                        commit { title = "A" }
-                        commit { title = "B" }
-                        commit { title = "0" }
-                        commit { title = "1" }
-                        commit { title = "2" }
-                        commit { title = "C" }
+                        commit {
+                            title = "A"
+                        }
+                        commit {
+                            title = "B"
+                        }
+                        commit {
+                            title = "0"
+                            id = ""
+                        }
+                        commit {
+                            title = "1"
+                            id = ""
+                        }
+                        commit {
+                            title = "2"
+                            id = ""
+                        }
+                        commit {
+                            title = "C"
+                        }
                         commit {
                             title = "D"
                             localRefs += "main"

--- a/git-kspr/src/test/kotlin/sims/michael/gitkspr/githubtests/GitHubTestHarness.kt
+++ b/git-kspr/src/test/kotlin/sims/michael/gitkspr/githubtests/GitHubTestHarness.kt
@@ -288,15 +288,18 @@ class GitHubTestHarness private constructor(
         file.writeText("Title: $title\n")
         // Use the title as the commit ID if ID wasn't provided
         val safeId = id
-        val commitId = if (safeId != null) {
-            safeId
-        } else {
-            require(!title.contains("\\s+".toRegex())) {
-                "ID wasn't provided and title '$title' can\'t be used as it contains whitespace."
+        val message = if (safeId == null || safeId.isNotBlank()) {
+            val commitId = safeId ?: title.also {
+                require(!it.contains("\\s+".toRegex())) {
+                    "ID wasn't provided and title '$it' can\'t be used as it contains whitespace."
+                }
             }
+            // Commit ID was non-blank (or null, in which case we fall back to the title)
+            localGit.appendCommitId(title, commitId)
+        } else {
+            // Commit ID was explicitly blank, do not add one
             title
         }
-        val message = localGit.appendCommitId(title, commitId)
         val safeWillPassVerification = willPassVerification
         return localGit
             .add(file.name)


### PR DESCRIPTION
Restore mechanism in GitHubTestHarness to create commits without IDs

I had inadvertently made it impossible to create test commits without
IDs which made the "push adds commit IDs" pointless and would have
prevented me from adding an upcoming test that will help prove the
absence of a bug I will be fixing (hope that made sense)

commit-id: 30b018b7
