### PR TITLE
Fix an indentation bug in commit ID rewriting logic

### DIFF
--- a/git-kspr/src/main/kotlin/sims/michael/gitkspr/JGitClient.kt
+++ b/git-kspr/src/main/kotlin/sims/michael/gitkspr/JGitClient.kt
@@ -200,13 +200,10 @@ class JGitClient(val workingDirectory: File, val remoteBranchPrefix: String = DE
         Git.cloneRepository().setDirectory(workingDirectory).setURI(uri).call().close()
     }
 
-    fun appendCommitId(fullMessage: String, commitId: String) =
-        """
-            $fullMessage
-
-            $COMMIT_ID_LABEL: $commitId
-
-        """.trimIndent()
+    fun appendCommitId(fullMessage: String, commitId: String): String {
+        val fullMessageTrimmed = fullMessage.trim()
+        return "$fullMessageTrimmed\n\n$COMMIT_ID_LABEL: $commitId\n"
+    }
 
     fun cherryPick(commit: Commit): Commit {
         logger.trace("cherryPick {}", commit)

--- a/git-kspr/src/test/kotlin/sims/michael/gitkspr/GitKsprTest.kt
+++ b/git-kspr/src/test/kotlin/sims/michael/gitkspr/GitKsprTest.kt
@@ -641,6 +641,42 @@ interface GitKsprTest {
         }
     }
 
+    @Test
+    fun `commit ID is appended successfully`() {
+        // assert the absence of a bug that used to occur with commits that had message bodies... the subject and footer
+        // lines would be indented, which was invalid and would cause the commit(s) to effectively have no ID
+        // if this test doesn't throw, then we're good
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "Bump EnricoMi/publish-unit-test-result-action from 2.1.0 to 2.11.0"
+                            body = """
+                                |Bumps [EnricoMi/publish-unit-test-result-action](https://github.com/enricomi/publish-unit-test-result-action) from 2.1.0 to 2.11.0.
+                                |- [Release notes](https://github.com/enricomi/publish-unit-test-result-action/releases)
+                                |- [Commits](https://github.com/enricomi/publish-unit-test-result-action/compare/713caf1dd6f1c273144546ed2d79ca24a01f4623...ca89ad036b5fcd524c1017287fb01b5139908408)
+                                |
+                                |---
+                                |updated-dependencies:
+                                |- dependency-name: EnricoMi/publish-unit-test-result-action
+                                |  dependency-type: direct:production
+                                |  update-type: version-update:semver-minor
+                                |...
+                                |
+                                |Signed-off-by: dependabot[bot] <support@github.com>
+                            """.trimMargin()
+                            id = ""
+                            localRefs += "main"
+                        }
+                    }
+                },
+            )
+
+            gitKspr.push()
+        }
+    }
+
     @TestFactory
     fun `push adds commit IDs`(): List<DynamicTest> {
         data class Test(val name: String, val expected: List<String>, val testCaseData: TestCaseData)

--- a/git-kspr/src/test/kotlin/sims/michael/gitkspr/GitKsprTest.kt
+++ b/git-kspr/src/test/kotlin/sims/michael/gitkspr/GitKsprTest.kt
@@ -650,10 +650,17 @@ interface GitKsprTest {
                 listOf("0", "1", "2"),
                 testCase {
                     repository {
-                        commit { title = "0" }
-                        commit { title = "1" }
+                        commit {
+                            title = "0"
+                            id = ""
+                        }
+                        commit {
+                            title = "1"
+                            id = ""
+                        }
                         commit {
                             title = "2"
+                            id = ""
                             localRefs += "main"
                         }
                     }
@@ -666,10 +673,17 @@ interface GitKsprTest {
                     repository {
                         commit { title = "A" }
                         commit { title = "B" }
-                        commit { title = "0" }
-                        commit { title = "1" }
+                        commit {
+                            title = "0"
+                            id = ""
+                        }
+                        commit {
+                            title = "1"
+                            id = ""
+                        }
                         commit {
                             title = "2"
+                            id = ""
                             localRefs += "main"
                         }
                     }
@@ -680,12 +694,27 @@ interface GitKsprTest {
                 listOf("A", "B", "0", "1", "2", "C", "D"),
                 testCase {
                     repository {
-                        commit { title = "A" }
-                        commit { title = "B" }
-                        commit { title = "0" }
-                        commit { title = "1" }
-                        commit { title = "2" }
-                        commit { title = "C" }
+                        commit {
+                            title = "A"
+                        }
+                        commit {
+                            title = "B"
+                        }
+                        commit {
+                            title = "0"
+                            id = ""
+                        }
+                        commit {
+                            title = "1"
+                            id = ""
+                        }
+                        commit {
+                            title = "2"
+                            id = ""
+                        }
+                        commit {
+                            title = "C"
+                        }
                         commit {
                             title = "D"
                             localRefs += "main"

--- a/git-kspr/src/test/kotlin/sims/michael/gitkspr/githubtests/GitHubTestHarness.kt
+++ b/git-kspr/src/test/kotlin/sims/michael/gitkspr/githubtests/GitHubTestHarness.kt
@@ -288,15 +288,18 @@ class GitHubTestHarness private constructor(
         file.writeText("Title: $title\n")
         // Use the title as the commit ID if ID wasn't provided
         val safeId = id
-        val commitId = if (safeId != null) {
-            safeId
-        } else {
-            require(!title.contains("\\s+".toRegex())) {
-                "ID wasn't provided and title '$title' can\'t be used as it contains whitespace."
+        val message = if (safeId == null || safeId.isNotBlank()) {
+            val commitId = safeId ?: title.also {
+                require(!it.contains("\\s+".toRegex())) {
+                    "ID wasn't provided and title '$it' can\'t be used as it contains whitespace."
+                }
             }
+            // Commit ID was non-blank (or null, in which case we fall back to the title)
+            localGit.appendCommitId(title, commitId)
+        } else {
+            // Commit ID was explicitly blank, do not add one
             title
         }
-        val message = localGit.appendCommitId(title, commitId)
         val safeWillPassVerification = willPassVerification
         return localGit
             .add(file.name)

--- a/git-kspr/src/test/kotlin/sims/michael/gitkspr/githubtests/GitHubTestHarness.kt
+++ b/git-kspr/src/test/kotlin/sims/michael/gitkspr/githubtests/GitHubTestHarness.kt
@@ -286,6 +286,11 @@ class GitHubTestHarness private constructor(
     private fun CommitData.create(): Commit {
         val file = localRepo.resolve("${title.sanitize()}.txt")
         file.writeText("Title: $title\n")
+        val titleAndBody = if (body.isNotEmpty()) {
+            title.trim() + "\n\n" + body.trim() + "\n"
+        } else {
+            title
+        }
         // Use the title as the commit ID if ID wasn't provided
         val safeId = id
         val message = if (safeId == null || safeId.isNotBlank()) {
@@ -298,7 +303,7 @@ class GitHubTestHarness private constructor(
             localGit.appendCommitId(title, commitId)
         } else {
             // Commit ID was explicitly blank, do not add one
-            title
+            titleAndBody
         }
         val safeWillPassVerification = willPassVerification
         return localGit

--- a/github-dsl-model/src/main/java/sims/michael/gitkspr/githubtests/GitHubDslModel.kt
+++ b/github-dsl-model/src/main/java/sims/michael/gitkspr/githubtests/GitHubDslModel.kt
@@ -27,6 +27,7 @@ interface Commit : DataClassFragment {
     val localRefs: SetPropertyNotNull<StringPropertyNotNull>
     val remoteRefs: SetPropertyNotNull<StringPropertyNotNull>
     val title: StringPropertyNotNull
+    val body: StringPropertyNotNull
     val prTitle: StringPropertyNotNull
     val prStartTitle: StringPropertyNotNull
     val prEndTitle: StringPropertyNotNull


### PR DESCRIPTION
Fix an indentation bug in commit ID rewriting logic

This was causing commits with bodies to have indented commit subjects
and footer lines, which was causing the ID to effectively not exist
and all sorts of things to go wrong

commit-id: 23322fb8
