### PR TITLE
Don't show failure when checks are in unknown state

### DIFF
--- a/git-kspr/src/main/kotlin/sims/michael/gitkspr/GitHubClient.kt
+++ b/git-kspr/src/main/kotlin/sims/michael/gitkspr/GitHubClient.kt
@@ -70,7 +70,11 @@ class GitHubClientImpl(
                         pr.baseRefName,
                         pr.title,
                         pr.body,
-                        state?.let { it == StatusState.SUCCESS },
+                        when (state) {
+                            StatusState.SUCCESS -> true
+                            StatusState.FAILURE, StatusState.ERROR -> false
+                            else -> null
+                        },
                         when (pr.reviewDecision) {
                             PullRequestReviewDecision.APPROVED -> true
                             PullRequestReviewDecision.CHANGES_REQUESTED -> false
@@ -107,6 +111,7 @@ class GitHubClientImpl(
                 // TODO looks like duplication but isn't, strictly. Still, this could be cleaned up by creating a facade
                 //   wrapper interface
                 val commitId = getCommitIdFromRemoteRef(pr.headRefName, remoteBranchPrefix)
+                val state = pr.commits.nodes?.singleOrNull()?.commit?.statusCheckRollup?.state
                 PullRequest(
                     pr.id,
                     commitId,
@@ -115,7 +120,11 @@ class GitHubClientImpl(
                     pr.baseRefName,
                     pr.title,
                     pr.body,
-                    pr.commits.nodes?.singleOrNull()?.commit?.statusCheckRollup?.state == StatusState.SUCCESS,
+                    when (state) {
+                        StatusState.SUCCESS -> true
+                        StatusState.FAILURE, StatusState.ERROR -> false
+                        else -> null
+                    },
                     when (pr.reviewDecision) {
                         PullRequestReviewDecision.APPROVED -> true
                         PullRequestReviewDecision.CHANGES_REQUESTED -> false
@@ -159,6 +168,7 @@ class GitHubClientImpl(
         //  duped since CreatePullRequest.Result is different from GetPullRequests.Result even though they both
         //  contain a PullRequest type
         val commitId = getCommitIdFromRemoteRef(pr.headRefName, remoteBranchPrefix)
+        val state = pr.commits.nodes?.singleOrNull()?.commit?.statusCheckRollup?.state
         return PullRequest(
             pr.id,
             commitId,
@@ -167,7 +177,11 @@ class GitHubClientImpl(
             pr.baseRefName,
             pr.title,
             pr.body,
-            pr.commits.nodes?.singleOrNull()?.commit?.statusCheckRollup?.state == StatusState.SUCCESS,
+            when (state) {
+                StatusState.SUCCESS -> true
+                StatusState.FAILURE, StatusState.ERROR -> false
+                else -> null
+            },
             when (pr.reviewDecision) {
                 PullRequestReviewDecision.APPROVED -> true
                 PullRequestReviewDecision.CHANGES_REQUESTED -> false


### PR DESCRIPTION
Don't show failure when checks are in unknown state

commit-id: Ie4d21bcb
