### PR TITLE
GitHubStubClient.getPullRequests should honor filter

### DIFF
--- a/git-kspr/src/test/kotlin/sims/michael/gitkspr/githubtests/GitHubStubClient.kt
+++ b/git-kspr/src/test/kotlin/sims/michael/gitkspr/githubtests/GitHubStubClient.kt
@@ -20,7 +20,12 @@ class GitHubStubClient(private val remoteBranchPrefix: String, private val local
         logger.trace("getPullRequests")
         return synchronized(prs) {
             autoClosePrs()
-            prs.openPullRequests()
+            if (commitFilter == null) {
+                prs.openPullRequests()
+            } else {
+                val ids = commitFilter.map { commit -> commit.id }
+                prs.openPullRequests().filter { pr -> pr.commitId in ids }
+            }
         }
     }
 
@@ -31,6 +36,7 @@ class GitHubStubClient(private val remoteBranchPrefix: String, private val local
         logger.trace("getPullRequestsById")
         return synchronized(prs) {
             autoClosePrs()
+            // TODO this looks suspect, if commitFilter is null we return nothing?
             prs.openPullRequests().filter { it.commitId in commitFilter.orEmpty() }
         }
     }


### PR DESCRIPTION
GitHubStubClient.getPullRequests should honor filter

Also add a TODO about another suspect bit of logic

⚠️ *Part of a stack created by [kspr](https://github.com/MichaelSims/git-kspr). Do not merge manually using the UI - doing so may have unexpected results.*
