### PR TITLE
External process test passes the right args in getAndPrintStatusString

### DIFF
--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprFunctionalExternalProcessTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprFunctionalExternalProcessTest.kt
@@ -54,7 +54,7 @@ class GitJasprFunctionalExternalProcessTest : GitJasprTest {
             extraCliArgs = emptyList(),
             homeDirConfig = buildHomeDirConfig(),
             repoDirConfig = emptyMap(),
-            strings = listOf("status", refSpec.toString()),
+            strings = listOf("status", DEFAULT_REMOTE_NAME, refSpec.toString()),
             invokeLocation = localRepo,
             javaOptions = javaOptions,
 


### PR DESCRIPTION
External process test passes the right args in getAndPrintStatusString

**Stack**:
- #104
- #103 ⬅
- #102
- #101
- #100
- #99
- #98
- #97
- #96
- #95
- #94
- #93
- #92
- #91
- #90
- #89
- #88

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
